### PR TITLE
Include current date in data for closing/deletion/archiving

### DIFF
--- a/webform_summary.module
+++ b/webform_summary.module
@@ -108,7 +108,7 @@ function _webform_summary_collect_open_webforms_ids()
 function _webform_summary_send_data(array $webformIds)
 {
   $startDate = new DateTime('1 year ago');
-  $endDate = new DateTime('1 days ago');
+  $endDate = new DateTime();
   \Drupal::logger('webform_summary')->notice('Sending webform summaries between ' . $startDate->format('Y/m/d') . ' and  ' . $endDate->format('Y/m/d'));
   $mailer = \Drupal::service('webform_summary.mailer');
   $mailer->setWebformIds($webformIds);


### PR DESCRIPTION
When deleting/archiving/closing a webform, data from the latest day was not included. This is now fixed.